### PR TITLE
return this if the proxy uri is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,10 @@ function proxy (uri) {
   if (Request && Request._proxies) proxies = Request._proxies;
   if (Request && Request._proxiesCache) cache = Request._proxiesCache;
 
+  if (!uri) {
+    return this;
+  }
+
   // parse the URI into an opts object if it's a String
   var proxyParsed = uri;
   if ('string' == typeof uri) {


### PR DESCRIPTION
Sometimes production env is different from development env.

In production config

```
config = {
  proxy: null
};
```

In development config

```
config = {
  proxy: 'http://10.1.10.200:3128'
};
```

It is nice to have this api syntax whatever the value of proxy is null or not.

```
var config = require('config');
request
    .get('http://www.google.com')
    .proxy(config.proxy)
    .end(function (res) {});
```

otherwise, i need to write something like this

```
var config = require('config');
req = request.get('http://www.google.com')
if (config.proxy) {
  req = req.proxy(config.proxy);
}
req.end(function (res) {});
```

more ugly
