### PR TITLE
support superagent >= 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "debug": "~0.7.4"
   },
   "peerDependencies": {
-    "superagent": ">= 0.15.4 && < 1"
+    "superagent": ">= 0.15.4"
   },
   "devDependencies": {
     "mocha": "~1.12.0",
-    "superagent": ">= 0.15.4 && < 1"
+    "superagent": ">= 0.15.4"
   }
 }


### PR DESCRIPTION
superagent-proxy works fine with superagent-proxy@1.1 and @1.2
but blocked by peerDependencies limit, so remove this will help forward compatible.