### PR TITLE
fixed example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ request
   .proxy(proxy)
   .end(onresponse);
 
-function onresponse (res) {
-  console.log(res.status, res.headers);
-  console.log(res.body);
+function onresponse (err, res) {
+  if (err) {
+    console.log(err);
+  } else {
+    console.log(res.status, res.headers);
+    console.log(res.body);
+  }
 }
 ```
 


### PR DESCRIPTION
The example in the Readme wasn't working for me. It turns out that the callback function for superagent's `.end()` function needs to take two arguments, an error and a response.