### PR TITLE
Upgrading debug dependency to avoid ReDoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "proxy-agent": "2",
-    "debug": "2"
+    "debug": "^3.1.0"
   },
   "peerDependencies": {
     "superagent": ">= 0.15.4 || 1 || 2 || 3"


### PR DESCRIPTION
There is a security issue with a subdependency (ms) in Debug < 3.1.0 - https://snyk.io/vuln/npm:debug:20170905 , would be nice if you can merge and create a new version