### PR TITLE
Update proxy-agent to 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.0.0 / 2018-07-11
+==================
+  * Upgrade "proxy-agent" to remove deprecation warning and enable socks v2
+  * drop support for Node < 6
+
 1.0.3 / 2018-02-12
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "superagent-proxy",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "`Request#proxy(uri)` superagent extension",
   "main": "index.js",
   "scripts": {
     "test": "mocha --reporter spec"
+  },
+  "engines": {
+    "node": ">=6"
   },
   "repository": {
     "type": "git",
@@ -23,7 +26,7 @@
     "url": "https://github.com/TooTallNate/superagent-proxy/issues"
   },
   "dependencies": {
-    "proxy-agent": "2",
+    "proxy-agent": "3",
     "debug": "^3.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Related:
---
https://github.com/TooTallNate/node-proxy-agent/pull/30
https://github.com/TooTallNate/node-proxy-agent/pull/31

Objective:
---
Update `proxy-agent` in order to remove `socks` deprecation warnings and to enable socks v2.

A new major version is required as moving to a newer version of `socks` means dropping Node < 6 support.