### PR TITLE
Update proxy-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/TooTallNate/superagent-proxy/issues"
   },
   "dependencies": {
-    "proxy-agent": "2",
+    "proxy-agent": "3",
     "debug": "^3.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This prevents the annoying deprecation warning:
```
npm WARN deprecated socks@1.1.10: If using 2.x branch, please upgrade to at least 2.1.6 to avoid a serious bug with socket data flow and an import issue introduced in 2.1.0
```