### PR TITLE
add a CI action with proxy services

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: 'CI'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      squid:
+        image: ubuntu/squid
+        env:
+          TZ: UTC
+        ports:
+          - '3128:3128'
+      socks:
+        image: serjs/go-socks5-proxy
+        ports:
+          - 1080:1080
+
+    strategy:
+      matrix:
+        node-version: [14, 16, 18, 20]
+
+    container: node:${{ matrix.node-version }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          http_proxy: http://squid:3128
+          https_proxy: http://squid:3128
+          socks_proxy: socks://socks:1080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+  test:
+    image: node:${NODE_VERSION:-16}-slim # Node 16 by default; "NODE_VERSION=<ver> docker-compose up" to run something different
+    user: node
+    working_dir: /home/node/app
+    environment:
+      http_proxy: http://squid:3128
+      https_proxy: http://squid:3128
+      socks_proxy: socks://socks:1080
+    volumes:
+      - ./:/home/node/app
+    command: "sleep infinity" # idle, use "docker-compose exec test npm <command>" after this is started
+
+  squid:
+    image: ubuntu/squid
+    environment:
+      - TZ=UTC
+    ports:
+      - 127.0.0.1:3128:3128
+
+  socks:
+    image: serjs/go-socks5-proxy
+    ports:
+      - 127.0.0.1:1080:1080


### PR DESCRIPTION
* adds a GitHub Actions workflow to run the tests with two live proxies (HTTP/s and SOCKS) for integration testing
* updates the tests:
  * use different target sites
  * check the new target content
  * skip the proxy integration tests if environment variables are not set
* includes the docker-compose config I used to test things locally and on which I set up the CI GitHub Action

This is not a very exciting PR without the workflow approved for running in this repo. Witness [the success over in my fork](https://github.com/robbkidd/superagent-proxy/pull/1/checks).